### PR TITLE
refactor: add support for vite version 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "vitest": "^3.1.2"
       },
       "peerDependencies": {
-        "vite": "^6.3.3"
+        "vite": ">=6.3.3 <8.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
-    "vite": "^6.3.3"
+    "vite": ">=6.3.3 <8.0.0"
   },
   "dependencies": {
     "@bugsnag/cli": "^3.1.0"


### PR DESCRIPTION
## Goal
Make this plugin available for applications with vite version 7

## Changeset
Version for `vite` is updated in `peerDependencies`

## Testing

### Compatibility Testing
- [x] `Vite 6.3.3`: Created test project with `Vite 6.3.3` and verified  work correctly
- [x] `Vite 7.1.4`: Created test project with `Vite 7.1.4` and verified  work correctly

### Plugin Testing
- [x] `BugsnagBuildReporterPlugin`: Tested build reporting functionality in both Vite versions
- [x] `BugsnagSourceMapUploaderPlugin`: Tested sourcemap upload functionality in both Vite versions

### Automated Tests
- All existing unit tests pass