### PR TITLE
Run unit tests in series to remove race conditions

### DIFF
--- a/test/source-map-uploader-plugin.test.ts
+++ b/test/source-map-uploader-plugin.test.ts
@@ -1,7 +1,7 @@
 import Bugsnag from '@bugsnag/cli'
 import { resolve } from 'path'
 import { build } from 'vite'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { BugsnagSourceMapUploaderPlugin } from '../src/source-map-uploader-plugin'
 import cleanBuildDir from './lib/clean-build-dir'
 
@@ -16,6 +16,10 @@ vi.mock('@bugsnag/cli', () => ({
 }))
 
 describe('BugsnagSourceMapUploaderPlugin', () => {
+    beforeEach(() => {
+        vi.mocked(Bugsnag.Upload.Js).mockClear()
+    })
+
     test('should return a valid plugin object', async () => {
         const plugin = BugsnagSourceMapUploaderPlugin({
             apiKey: 'test-api',
@@ -78,8 +82,6 @@ describe('BugsnagSourceMapUploaderPlugin', () => {
             },
             outputDir
         )
-        
-        sourcemapUpload.mockClear()
     })
 
     test('should use the relative filepath for bundleUrl if base is not provided in config', async () => {
@@ -123,8 +125,6 @@ describe('BugsnagSourceMapUploaderPlugin', () => {
             },
             outputDir
         )
-
-        sourcemapUpload.mockClear()
     })
 
     test('logs an error if the upload fails', async () => {
@@ -159,7 +159,5 @@ describe('BugsnagSourceMapUploaderPlugin', () => {
         expect(mockLogger.info).toHaveBeenCalledWith('[BugsnagSourceMapUploaderPlugin] uploading sourcemaps using the bugsnag-cli')
         expect(mockLogger.error).toHaveBeenCalledWith('[BugsnagSourceMapUploaderPlugin] Error: Upload failed')
         expect(mockLogger.info).not.toHaveBeenCalledWith('[BugsnagSourceMapUploaderPlugin] Sourcemaps uploaded successfully')
-
-        sourcemapUpload.mockClear()
     })
 })

--- a/test/source-map-uploader-plugin.test.ts
+++ b/test/source-map-uploader-plugin.test.ts
@@ -67,21 +67,22 @@ describe('BugsnagSourceMapUploaderPlugin', () => {
 
         const sourcemapUpload = vi.mocked(Bugsnag.Upload.Js)
         const outputDir = resolve(fixturesPath, 'dist')
-        const bundlePath = resolve(outputDir, 'assets/index-DTHX3LI9.js')
-        const sourceMapPath = resolve(outputDir, 'assets/index-DTHX3LI9.js.map')
 
         expect(mockLogger.info).toHaveBeenCalledWith('[BugsnagSourceMapUploaderPlugin] uploading sourcemaps using the bugsnag-cli')
         expect(mockLogger.info).toHaveBeenCalledWith('[BugsnagSourceMapUploaderPlugin] Sourcemaps uploaded successfully')
-        expect(sourcemapUpload).toHaveBeenCalledExactlyOnceWith({
-                apiKey: 'test-api',
-                bundleUrl: 'https://bugsnag.com/assets/index-DTHX3LI9.js',
-                bundle: bundlePath,
-                projectRoot: fixturesPath,
-                sourceMap: sourceMapPath,
-                versionName: '1.0.0'
-            },
-            outputDir
-        )
+        expect(sourcemapUpload).toHaveBeenCalledOnce()
+        
+        const [uploadOptions, targetDir] = sourcemapUpload.mock.calls[0]
+        expect(uploadOptions).toBeDefined()
+        expect(uploadOptions).toMatchObject({
+            apiKey: 'test-api',
+            projectRoot: fixturesPath,
+            versionName: '1.0.0'
+        })
+        expect(uploadOptions!.bundleUrl).toMatch(/^https:\/\/bugsnag\.com\/assets\/index-[a-zA-Z0-9]+\.js$/)
+        expect(uploadOptions!.bundle).toMatch(/\/assets\/index-[a-zA-Z0-9]+\.js$/)
+        expect(uploadOptions!.sourceMap).toMatch(/\/assets\/index-[a-zA-Z0-9]+\.js\.map$/)
+        expect(targetDir).toBe(outputDir)
     })
 
     test('should use the relative filepath for bundleUrl if base is not provided in config', async () => {
@@ -110,21 +111,22 @@ describe('BugsnagSourceMapUploaderPlugin', () => {
 
         const sourcemapUpload = vi.mocked(Bugsnag.Upload.Js)
         const outputDir = resolve(fixturePath, 'dist')
-        const bundlePath = resolve(outputDir, 'assets/index-DTHX3LI9.js')
-        const sourceMapPath = resolve(outputDir, 'assets/index-DTHX3LI9.js.map')
 
         expect(mockLogger.info).toHaveBeenCalledWith('[BugsnagSourceMapUploaderPlugin] uploading sourcemaps using the bugsnag-cli')
         expect(mockLogger.info).toHaveBeenCalledWith('[BugsnagSourceMapUploaderPlugin] Sourcemaps uploaded successfully')
-        expect(sourcemapUpload).toHaveBeenCalledExactlyOnceWith({
-                apiKey: 'test-api',
-                bundleUrl: '/assets/index-DTHX3LI9.js',
-                bundle: bundlePath,
-                projectRoot: fixturePath,
-                sourceMap: sourceMapPath,
-                versionName: version
-            },
-            outputDir
-        )
+        expect(sourcemapUpload).toHaveBeenCalledOnce()
+        
+        const [uploadOptions, targetDir] = sourcemapUpload.mock.calls[0]
+        expect(uploadOptions).toBeDefined()
+        expect(uploadOptions).toMatchObject({
+            apiKey: 'test-api',
+            projectRoot: fixturePath,
+            versionName: version
+        })
+        expect(uploadOptions!.bundleUrl).toMatch(/^\/assets\/index-[a-zA-Z0-9]+\.js$/)
+        expect(uploadOptions!.bundle).toMatch(/\/assets\/index-[a-zA-Z0-9]+\.js$/)
+        expect(uploadOptions!.sourceMap).toMatch(/\/assets\/index-[a-zA-Z0-9]+\.js\.map$/)
+        expect(targetDir).toBe(outputDir)
     })
 
     test('logs an error if the upload fails', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // Run tests in sequence to avoid race conditions with shared fixture directories
+    fileParallelism: false
+  }
+})


### PR DESCRIPTION
## Goal

Fix failing unit tests by serialising test case runner and ensuring bundle name assertions are less strict