### PR TITLE
Add support for Vite v7

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         node: [22] 
-        vite: [6] # 4,5,6 still supported
+        vite: [6,7] # 4,5,6 still supported
     env:
       VITE_VERSION: ${{ matrix.vite }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+
+- Added support for Vite v7 [#13](https://github.com/bugsnag/vite-plugin-bugsnag/pull/13)
+
 ## [1.0.0] - 2025-06-25
 
 Initial release 🚀

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "vitest": "^3.1.2"
       },
       "peerDependencies": {
-        "vite": ">=6.3.3 <8.0.0"
+        "vite": ">=6.0.0  || >=7.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "vitest": "^3.1.2"
       },
       "peerDependencies": {
-        "vite": "^6.3.3"
+        "vite": ">=6.3.3 <8.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
-    "vite": ">=6.3.3 <8.0.0"
+    "vite": ">=6.0.0  || >=7.0.0"
   },
   "dependencies": {
     "@bugsnag/cli": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
-    "vite": ">=6.0.0  || >=7.0.0"
+    "vite": ">=6.0.0 || >=7.0.0"
   },
   "dependencies": {
     "@bugsnag/cli": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
-    "vite": "^6.3.3"
+    "vite": ">=6.3.3 <8.0.0"
   },
   "dependencies": {
     "@bugsnag/cli": "^3.1.0"


### PR DESCRIPTION
## Goal

Make this plugin available for applications with vite version 7

## Changeset

Version for `vite` is updated in `peerDependencies`

## Testing

### Compatibility Testing
- [x] `Vite 6.3.3`: Created test project with `Vite 6.3.3` and verified  work correctly
- [x] `Vite 7.1.4`: Created test project with `Vite 7.1.4` and verified  work correctly

### Plugin Testing
- [x] `BugsnagBuildReporterPlugin`: Tested build reporting functionality in both Vite versions
- [x] `BugsnagSourceMapUploaderPlugin`: Tested sourcemap upload functionality in both Vite versions

### Automated Tests

- Updated unit test matrix to include v7 
- All existing unit tests pass